### PR TITLE
changing --http-allowed-codes parameter to return integers.

### DIFF
--- a/proxybroker/cli.py
+++ b/proxybroker/cli.py
@@ -211,6 +211,7 @@ def add_serve_args(group):
     group.add_argument(
         '--http-allowed-codes',
         nargs='+',
+        type=int,
         dest='http_allowed_codes',
         help='Acceptable HTTP codes returned by proxy on requests')
     group.add_argument(

--- a/proxybroker/server.py
+++ b/proxybroker/server.py
@@ -242,4 +242,4 @@ class Server:
             except BadStatusLine:
                 raise BadResponseError
             if header['Status'] not in self._http_allowed_codes:
-                raise BadStatusError
+                raise BadStatusError('%r not in %r' %(header['Status'], self._http_allowed_codes))


### PR DESCRIPTION
--http-allowed-codes parameter was broken, it tried to match an int in a list of strings.

Awesome feature btw 👍 
