### PR TITLE
Fix aiohttp deprecation warning and log level

### DIFF
--- a/proxybroker/providers.py
+++ b/proxybroker/providers.py
@@ -153,13 +153,13 @@ class Provider:
                         page = await resp.text()
                     else:
                         error_page = await resp.text()
-                        log.error('url: %s\nheaders: %s\ncookies: %s\npage:\n%s' % (
+                        log.debug('url: %s\nheaders: %s\ncookies: %s\npage:\n%s' % (
                                   url, resp.headers, resp.cookies, error_page))
                         raise BadStatusError('Status: %s' % resp.status)
         except (UnicodeDecodeError, BadStatusError, asyncio.TimeoutError,
                 aiohttp.ClientOSError, aiohttp.ClientResponseError,
                 aiohttp.ServerDisconnectedError) as e:
-            log.error('%s is failed. Error: %r;' % (url, e))
+            log.debug('%s is failed. Error: %r;' % (url, e))
         return page
 
     def find_proxies(self, page):

--- a/proxybroker/resolver.py
+++ b/proxybroker/resolver.py
@@ -62,9 +62,9 @@ class Resolver:
     async def get_real_ext_ip(self):
         """Return real external IP address."""
         try:
-            with aiohttp.Timeout(self._timeout, loop=self._loop),\
-                    aiohttp.ClientSession(loop=self._loop) as session:
-                async with session.get('http://httpbin.org/ip') as resp:
+            with aiohttp.Timeout(self._timeout, loop=self._loop):
+                async with aiohttp.ClientSession(loop=self._loop) as session,\
+                        session.get('http://httpbin.org/ip') as resp:
                     data = await resp.json()
         except asyncio.TimeoutError as e:
             raise RuntimeError('Could not get a external IP. Error: %s' % e)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,10 +1,8 @@
-import unittest
 from unittest.mock import Mock, patch
 
 from .utils import AsyncTestCase, ResolveResult, future_iter
 
 import socket
-from asyncio import Future
 from proxybroker.errors import ResolveError
 from proxybroker.resolver import Resolver
 
@@ -31,16 +29,12 @@ class TestResolver(AsyncTestCase):
     async def test_get_real_ext_ip(self):
         rs = Resolver(timeout=0.1)
 
-        def side_effect(*args, **kwargs):
-            def _side_effect(*args, **kwargs):
-                fut = Future()
-                fut.set_result({'origin': '127.0.0.1'})
-                return fut
+        async def side_effect(*args, **kwargs):
+            async def _side_effect(*args, **kwargs):
+                return {'origin': '127.0.0.1'}
             resp = Mock()
             resp.json.side_effect = resp.release.side_effect = _side_effect
-            fut = Future()
-            fut.set_result(resp)
-            return fut
+            return resp
 
         with patch("aiohttp.client.ClientSession._request") as resp:
             resp.side_effect = side_effect


### PR DESCRIPTION
In current version aiohttp throws DeprecationWarning because we don't use asynchronous context managers for sessions. 
As we use python 3.5, I think it's ok to use them. 
And also I fixed logging levels for some errors. I think it's a common error when proxy broker receives 500 HTTP code from proxy list site, because it is broken. But it is not an error of proxybroker and we should not log it with error level. I made logging these errors with lower level.

For now with these fixes, when we execute simple script from example folder we don't see any errors and get correct result.

What do you think about it, @constverum ?