### PR TITLE
Updated examples

### DIFF
--- a/examples/find_and_use.py
+++ b/examples/find_and_use.py
@@ -55,11 +55,10 @@ def fetch_page_by_requests(url, proxy_url, timeout):
 
 async def fetch_page_by_aiohttp(url, proxy_url, timeout, loop):
     resp = None
-    conn = aiohttp.ProxyConnector(proxy_url)
     try:
-        with aiohttp.ClientSession(connector=conn, loop=loop) as session,\
+        with aiohttp.ClientSession(loop=loop) as session,\
              aiohttp.Timeout(timeout):
-            async with session.get(url) as response:
+            async with session.get(url, proxy=proxy_url) as response:
                 logger.info('url: %s; status: %d' % (url, response.status))
                 resp = await response.read()
     except (aiohttp.errors.ClientOSError, aiohttp.errors.ClientResponseError,

--- a/examples/proxy_server.py
+++ b/examples/proxy_server.py
@@ -10,17 +10,17 @@ from proxybroker import Broker
 
 async def get_pages(urls, proxy_url):
     tasks = [
-        fetch_page(url, aiohttp.ProxyConnector(proxy_url)) for url in urls]
+        fetch_page(url, proxy_url) for url in urls]
     for task in asyncio.as_completed(tasks):
         url, content = await task
         print('url: %s; content: %.100s' % (url, content))
 
 
-async def fetch_page(url, conn):
+async def fetch_page(url, proxy_url):
     resp = None
     try:
-        with aiohttp.ClientSession(connector=conn) as session:
-            async with session.get(url) as response:
+        with aiohttp.ClientSession() as session:
+            async with session.get(url, proxy=proxy_url) as response:
                 logger.info('url: %s; status: %d' % (url, response.status))
                 resp = await response.read()
     except (aiohttp.errors.ClientOSError, aiohttp.errors.ClientResponseError,


### PR DESCRIPTION
Removed aiohttp.ProxyConnector from examples because it was dropped from aiohttp:

http://aiohttp.readthedocs.io/en/latest/changes.html?highlight=proxyconnector#rc1-2017-03-15