### PR TITLE
Added "INFO" logging as default; changed 'started server' print to log.INFO; changed client connect log from DEBUG to INFO.

### DIFF
--- a/proxybroker/api.py
+++ b/proxybroker/api.py
@@ -293,7 +293,7 @@ class Broker:
         Transform the passed data from [raw string | file-like object | list]
         to set {(host, port), ...}: {('192.168.0.1', '80'), }
         """
-        log.debug('Load proxies from the raw data')
+        log.trace('Load proxies from the raw data')
         if isinstance(data, io.TextIOWrapper):
             data = data.read()
         if isinstance(data, str):
@@ -320,18 +320,18 @@ class Broker:
                 self._all_tasks.extend(tasks)
                 yield tasks
 
-        log.debug('Start grabbing proxies')
+        log.trace('Start grabbing proxies')
         while True:
             for tasks in _get_tasks():
                 for task in asyncio.as_completed(tasks):
                     proxies = await task
                     for proxy in proxies:
                         await self._handle(proxy, check=check)
-            log.debug('Grab cycle is complete')
+            log.trace('Grab cycle is complete')
             if self._server:
-                log.debug('fall asleep for %d seconds' % GRAB_PAUSE)
+                log.trace('fall asleep for %d seconds' % GRAB_PAUSE)
                 await asyncio.sleep(GRAB_PAUSE)
-                log.debug('awaked')
+                log.trace('awaked')
             else:
                 break
         await self._on_check.join()
@@ -384,12 +384,12 @@ class Broker:
                 pass
 
         if self._server and not self._proxies.empty() and self._limit <= 0:
-            log.debug(
+            log.trace(
                 'pause. proxies: %s; limit: %s'
                 % (self._proxies.qsize(), self._limit)
             )
             await self._proxies.join()
-            log.debug('unpause. proxies: %s' % self._proxies.qsize())
+            log.trace('unpause. proxies: %s' % self._proxies.qsize())
 
         await self._on_check.put(None)
         task = asyncio.ensure_future(self._checker.check(proxy))
@@ -397,7 +397,7 @@ class Broker:
         self._all_tasks.append(task)
 
     def _push_to_result(self, proxy):
-        log.debug('push to result: %r' % proxy)
+        log.trace('push to result: %r' % proxy)
         self._proxies.put_nowait(proxy)
         self._update_limit()
 
@@ -415,7 +415,7 @@ class Broker:
         log.info('Stop!')
 
     def _done(self):
-        log.debug('called done')
+        log.trace('called done')
         while self._all_tasks:
             task = self._all_tasks.pop()
             if not task.done():

--- a/proxybroker/checker.py
+++ b/proxybroker/checker.py
@@ -58,14 +58,14 @@ class Checker:
 
     async def check_judges(self):
         # TODO: need refactoring
-        log.debug('Start check judges')
+        log.trace('Start check judges')
         stime = time.time()
         await asyncio.gather(
             *[j.check(real_ext_ip=self._real_ext_ip) for j in self._judges]
         )
 
         self._judges = [j for j in self._judges if j.is_working]
-        log.debug(
+        log.trace(
             '%d judges added. Runtime: %.4f;'
             % (len(self._judges), time.time() - stime)
         )
@@ -105,7 +105,7 @@ class Checker:
                 UserWarning,
             )
         if self._judges:
-            log.debug('Loaded: %d proxy judges' % len(set(self._judges)))
+            log.trace('Loaded: %d proxy judges' % len(set(self._judges)))
         else:
             RuntimeError('Not found judges')
 
@@ -280,7 +280,7 @@ async def _send_test_request(method, proxy, judge):
         raise err
     finally:
         proxy.log('Get: %s' % ('success' if content else 'failed'), err=err)
-        log.debug(
+        log.trace(
             '{h}:{p} [{n}]: ({j}) rv: {rv}, response: {resp}'.format(
                 h=proxy.host,
                 p=proxy.port,

--- a/proxybroker/cli.py
+++ b/proxybroker/cli.py
@@ -146,7 +146,7 @@ def add_broker_args(group):
     group.add_argument(
         '--log',
         nargs='?',
-        default=logging.CRITICAL,
+        default=logging.INFO,
         choices=['NOTSET', 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
         help='Logging level',
     )
@@ -370,6 +370,9 @@ def cli(args=sys.argv[1:]):
         format='%(asctime)s - %(levelname)s - %(name)s - %(message)s',
         datefmt='[%H:%M:%S]',
         level=ns.log,
+        handlers=[
+            logging.StreamHandler()
+        ]
     )
 
     if hasattr(ns, 'anon_lvl') and 'HTTP' in ns.types:
@@ -426,7 +429,6 @@ def cli(args=sys.argv[1:]):
             strict=ns.strict,
             dnsbl=ns.dnsbl,
         )
-        print('Server started at http://%s:%d' % (ns.host, ns.port))
 
     try:
         if tasks:

--- a/proxybroker/judge.py
+++ b/proxybroker/judge.py
@@ -86,7 +86,7 @@ class Judge:
             aiohttp.ClientResponseError,
             aiohttp.ServerDisconnectedError,
         ) as e:
-            log.debug('%s is failed. Error: %r;' % (self, e))
+            log.trace('%s is failed. Error: %r;' % (self, e))
             return
 
         page = page.lower()
@@ -97,9 +97,9 @@ class Judge:
             self.is_working = True
             self.available[self.scheme].append(self)
             self.ev[self.scheme].set()
-            log.debug('%s is verified' % self)
+            log.trace('%s is verified' % self)
         else:
-            log.debug(
+            log.trace(
                 (
                     '{j} is failed. HTTP status code: {code}; '
                     'Real IP on page: {ip}; Version: {word}; '

--- a/proxybroker/providers.py
+++ b/proxybroker/providers.py
@@ -72,14 +72,14 @@ class Provider:
 
         :return: :attr:`.proxies`
         """
-        log.debug('Try to get proxies from %s' % self.domain)
+        log.trace('Try to get proxies from %s' % self.domain)
 
         async with aiohttp.ClientSession(
             headers=get_headers(), cookies=self._cookies, loop=self._loop
         ) as self._session:
             await self._pipe()
 
-        log.debug(
+        log.trace(
             '%d proxies received from %s: %s'
             % (len(self.proxies), self.domain, self.proxies)
         )
@@ -114,7 +114,7 @@ class Provider:
             )
         self.proxies = received
         added = len(self.proxies) - oldcount
-        log.debug(
+        log.trace(
             '%d(%d) proxies added(received) from %s'
             % (added, len(received), url)
         )
@@ -137,7 +137,7 @@ class Provider:
             ) as resp:
                 page = await resp.text()
                 if resp.status != 200:
-                    log.debug(
+                    log.trace(
                         'url: %s\nheaders: %s\ncookies: %s\npage:\n%s'
                         % (url, resp.headers, resp.cookies, page)
                     )
@@ -151,7 +151,7 @@ class Provider:
             aiohttp.ServerDisconnectedError,
         ) as e:
             page = ''
-            log.debug('%s is failed. Error: %r;' % (url, e))
+            log.trace('%s is failed. Error: %r;' % (url, e))
         return page
 
     def find_proxies(self, page):

--- a/proxybroker/proxy.py
+++ b/proxybroker/proxy.py
@@ -262,7 +262,7 @@ class Proxy:
     def log(self, msg, stime=0, err=None):
         ngtr = self.ngtr.name if self.ngtr else 'INFO'
         runtime = time.time() - stime if stime else 0
-        log.debug(
+        log.trace(
             '{h}:{p} [{n}]: {msg}; Runtime: {rt:.2f}'.format(
                 h=self.host, p=self.port, n=ngtr, msg=msg, rt=runtime
             )
@@ -314,7 +314,7 @@ class Proxy:
             err = ProxyConnError(msg)
             raise err
         # except asyncio.CancelledError:
-        #     log.debug('Cancelled in proxy.connect()')
+        #     log.trace('Cancelled in proxy.connect()')
         #     raise ProxyConnError()
         else:
             msg += 'Connection: success'

--- a/proxybroker/resolver.py
+++ b/proxybroker/resolver.py
@@ -103,7 +103,7 @@ class Resolver:
             else:
                 ip = ip.strip()
                 if self.host_is_ip(ip):
-                    log.debug('Real external IP: %s', ip)
+                    log.trace('Real external IP: %s', ip)
                     break
         else:
             raise RuntimeError('Could not get the external IP')
@@ -139,7 +139,7 @@ class Resolver:
             else:
                 self._cached_hosts[host] = hosts[0]['host']
             if logging:
-                log.debug(
+                log.trace(
                     '%s: Host resolved: %s' % (host, self._cached_hosts[host])
                 )
         else:

--- a/proxybroker/server.py
+++ b/proxybroker/server.py
@@ -61,12 +61,12 @@ class ProxyPool:
             (proxy.error_rate > self._max_error_rate)
             or (proxy.avg_resp_time > self._max_resp_time)
         ):
-            log.debug(
+            log.trace(
                 '%s:%d removed from proxy pool' % (proxy.host, proxy.port)
             )
         else:
             heapq.heappush(self._pool, (proxy.priority, proxy))
-        log.debug('%s:%d stat: %s' % (proxy.host, proxy.port, proxy.stat))
+        log.trace('%s:%d stat: %s' % (proxy.host, proxy.port, proxy.stat))
 
 
 class Server:
@@ -86,7 +86,7 @@ class Server:
         http_allowed_codes=None,
         backlog=100,
         loop=None,
-        **kwargs
+        **kwargs,
     ):
         self.host = host
         self.port = int(port)
@@ -139,11 +139,11 @@ class Server:
         def _on_completion(f):
             reader, writer = self._connections.pop(f)
             writer.close()
-            log.debug('client: %d; closed' % id(client_reader))
+            log.trace('client: %d; closed' % id(client_reader))
             try:
                 exc = f.exception()
             except asyncio.CancelledError:
-                log.debug('CancelledError in server._handle:_on_completion')
+                log.trace('CancelledError in server._handle:_on_completion')
                 exc = None
             if exc:
                 if isinstance(exc, NoProxyError):
@@ -164,7 +164,7 @@ class Server:
         request, headers = await self._parse_request(client_reader)
         scheme = self._identify_scheme(headers)
         client = id(client_reader)
-        log.debug(
+        log.trace(
             'client: %d; request: %s; headers: %s; scheme: %s'
             % (client, request, headers, scheme)
         )
@@ -212,7 +212,7 @@ class Server:
                 ]
                 await asyncio.gather(*stream, loop=self._loop)
             except asyncio.CancelledError:
-                log.debug('Cancelled in server._handle')
+                log.trace('Cancelled in server._handle')
                 break
             except (
                 ProxyTimeoutError,
@@ -223,10 +223,10 @@ class Server:
                 BadStatusError,
                 BadResponseError,
             ) as e:
-                log.debug('client: %d; error: %r' % (client, e))
+                log.trace('client: %d; error: %r' % (client, e))
                 continue
             except ErrorOnStream as e:
-                log.debug(
+                log.trace(
                     'client: %d; error: %r; EOF: %s'
                     % (client, e, client_reader.at_eof())
                 )

--- a/proxybroker/server.py
+++ b/proxybroker/server.py
@@ -156,7 +156,7 @@ class Server:
         self._connections[f] = (client_reader, client_writer)
 
     async def _handle(self, client_reader, client_writer):
-        log.debug(
+        log.info(
             'Accepted connection from %s'
             % (client_writer.get_extra_info('peername'),)
         )
@@ -173,7 +173,7 @@ class Server:
             stime, err = 0, None
             proxy = await self._proxy_pool.get(scheme)
             proto = self._choice_proto(proxy, scheme)
-            log.debug(
+            log.info(
                 'client: %d; attempt: %d; proxy: %s; proto: %s'
                 % (client, attempt, proxy, proto)
             )


### PR DESCRIPTION
For testing purposes on my end, I changed some of the logging variables within the project to better reflect the README.md printout. 

![Screen Shot 2019-06-01 at 1 52 33 PM](https://user-images.githubusercontent.com/2829082/58751959-8beabb80-8474-11e9-9e1a-c0bef46e0524.png)

Do note that when logging level is manually set on the command line to a higher log level (i.e. `proxybroker --log DEBUG`), the Python `logging` module will print all log levels below as well. This means that even on `DEBUG`, `INFO` will be printed.
