### PR TITLE
Added man-in-the-middle attack for proper HTTPS header checking.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__
 build
 dist
 pip-wheel-metadata
+.ropeproject

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 .cache
 build
 dist
+pip-wheel-metadata

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build
 dist
 pip-wheel-metadata
 .ropeproject
+.python-version

--- a/proxybroker/api.py
+++ b/proxybroker/api.py
@@ -59,7 +59,7 @@ class Broker:
         providers=None,
         verify_ssl=False,
         loop=None,
-        **kwargs
+        **kwargs,
     ):
         self._loop = loop or asyncio.get_event_loop()
         self._proxies = queue or asyncio.Queue(loop=self._loop)
@@ -133,7 +133,7 @@ class Broker:
         strict=False,
         dnsbl=None,
         limit=0,
-        **kwargs
+        **kwargs,
     ):
         """Gather and check proxies from providers or from a passed data.
 
@@ -280,9 +280,9 @@ class Broker:
             timeout=self._timeout,
             max_tries=kwargs.pop('max_tries', self._max_tries),
             loop=self._loop,
-            **kwargs
+            **kwargs,
         )
-        self._server.start()
+        asyncio.ensure_future(self._server.start())
 
         task = asyncio.ensure_future(self.find(limit=limit, **kwargs))
         self._all_tasks.append(task)

--- a/proxybroker/api.py
+++ b/proxybroker/api.py
@@ -412,7 +412,7 @@ class Broker:
         if self._server:
             self._server.stop()
             self._server = None
-        log.info('Stop!')
+        log.debug('Stop!')
 
     def _done(self):
         log.debug('called done')
@@ -421,7 +421,7 @@ class Broker:
             if not task.done():
                 task.cancel()
         self._push_to_result(None)
-        log.info('Done! Total found proxies: %d' % len(self.unique_proxies))
+        log.debug('Done! Total found proxies: %d' % len(self.unique_proxies))
 
     def show_stats(self, verbose=False, **kwargs):
         """Show statistics on the found proxies.

--- a/proxybroker/cli.py
+++ b/proxybroker/cli.py
@@ -426,8 +426,7 @@ def cli(args=sys.argv[1:]):
             strict=ns.strict,
             dnsbl=ns.dnsbl,
         )
-        print('Server started at http://%s:%d' % (ns.host, ns.port))
-
+        
     try:
         if tasks:
             loop.run_until_complete(asyncio.gather(*tasks, loop=loop))

--- a/proxybroker/interceptor.py
+++ b/proxybroker/interceptor.py
@@ -1,0 +1,412 @@
+from http_parser.parser import HttpParser
+from OpenSSL import crypto
+from socket import gethostname
+import traceback
+import asyncio
+import aiohttp
+import time
+import ssl
+import os
+
+from .utils import log
+from .errors import (
+    BadResponseError,
+    BadStatusError,
+    ErrorOnStream,
+    ProxyConnError,
+    ProxyEmptyRecvError,
+    ProxyRecvError,
+    ProxySendError,
+    ProxyTimeoutError,
+)
+
+
+def create_self_signed_cert():
+    """ Generates self signed SSL certificate. """
+
+    # Creates key pair.
+    k = crypto.PKey()
+    k.generate_key(crypto.TYPE_RSA, 1024)
+
+    # Creates self-signed certificate.
+    cert = crypto.X509()
+    cert.get_subject().C = "US"
+    cert.get_subject().ST = "New York"
+    cert.get_subject().L = "New York"
+    cert.get_subject().O = "."
+    cert.get_subject().OU = "."
+    cert.get_subject().CN = gethostname()
+    cert.set_serial_number(1000)
+    cert.gmtime_adj_notBefore(0)
+    cert.gmtime_adj_notAfter(10 * 365 * 24 * 60 * 60)
+    cert.set_issuer(cert.get_subject())
+    cert.set_pubkey(k)
+    cert.sign(k, "sha1")
+
+    if not os.path.exists("ssl"):
+        os.makedirs("ssl")
+
+    with open("ssl/server.crt", "wb") as f:
+        f.write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert))
+
+    with open("ssl/server.key", "wb") as f:
+        f.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, k))
+
+
+class EmulatedClient(object):
+    """ Class for emulating the client to the server. """
+
+    def __init__(
+        self,
+        loop,
+        timeout,
+        max_tries,
+        prefer_connect,
+        http_allowed_codes,
+        proxy_pool,
+        resolver,
+        connect_statement=None,
+    ):
+        # Setting the class variables.
+        self._loop = loop
+        self._timeout = timeout
+        self._max_tries = max_tries
+        self._prefer_connect = prefer_connect
+        self._http_allowed_codes = http_allowed_codes
+        self._proxy_pool = proxy_pool
+        self._resolver = resolver
+        self._connect_statement = connect_statement
+
+        # Last response gathered to return back to client.
+        self._last_resp = None
+
+    async def connect(self, data):
+
+        scheme = 'HTTPS' if self._connect_statement else 'HTTP'
+
+        for attempt in range(self._max_tries):
+            # Setting intial variables for proxy filtering (if needed).
+            stime, err = 0, None
+
+            # Gets a proxy from the Proxy pool.
+            proxy = await self._proxy_pool.get(scheme)
+
+            # Parses the incoming data.
+            http_parser = HttpParser()
+            http_parser.execute(data, len(data))
+            host = http_parser.get_wsgi_environ()['HTTP_HOST']
+            uri = http_parser.get_wsgi_environ()['RAW_URI']
+
+            # Sets the proper URL client is trying to reach.
+            if self._connect_statement:
+                url = f"https://{host}:{uri}"
+            else:
+                url = uri
+
+            try:
+                await proxy.connect()
+
+                log.info(
+                    f"Attempting to reach {host} for the {attempt} time, with proxy {proxy.host}:{proxy.port}."
+                )
+
+                # Begins the streaming between the client and the proxy.
+                resp = asyncio.create_task(self.stream(proxy, data, url))
+                await asyncio.wait_for(resp, timeout=self._timeout)
+
+                # If the response exists, return it.
+                if resp:
+                    log.info(
+                        f"Successfully reached host {host}. Returning data to client."
+                    )
+                    return resp.result()
+
+                # Saves the proxy time.
+                stime = time.time()
+
+            except asyncio.TimeoutError:
+                log.debug(
+                    f"Timeout error with proxy {proxy.host}:{proxy.port}. Flagging from pool."
+                )
+                continue
+            except ErrorOnStream as e:
+                if "Proxy error" in e:
+                    log.debug(
+                        f"Issue with proxy {proxy.host}:{proxy.port}. Flagging from pool."
+                    )
+
+                if "Response error" in e:
+                    log.debug(f"Issue with getting the response.")
+                continue
+            except Exception:
+                # Prints the traceback if the exception is not caught.
+                traceback.print_exc()
+                continue
+            finally:
+                proxy.log(data.decode(), stime, err=err)
+                proxy.close()
+                self._proxy_pool.put(proxy)
+
+        # Here if all the attempts were exhausted without success.
+        return self._last_resp
+
+    async def stream(self, proxy, data, url):
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    url, proxy=f"http://{proxy.host}:{proxy.port}", ssl=False
+                ) as response:
+                    status = response.status
+                    resp = await response.text()
+
+            if resp and status in self._http_allowed_codes:
+                self._last_resp = resp.encode()
+                return resp.encode()
+            else:
+                raise ErrorOnStream("Response is invalid.")
+        except (
+            ProxyTimeoutError,
+            ProxyConnError,
+            ProxyRecvError,
+            ProxySendError,
+            ProxyEmptyRecvError,
+        ) as e:
+            raise ErrorOnStream(f"Proxy error. {e}")
+        except (
+            asyncio.TimeoutError,
+            ConnectionResetError,
+            OSError,
+            BadStatusError,
+            BadResponseError,
+        ) as e:
+            raise ErrorOnStream(f"Response error. {e}")
+
+    def check_proxy_protocol(self, proxy, scheme):
+        if scheme == 'HTTP':
+            if self._prefer_connect and ('CONNECT:80' in proxy.types):
+                proto = 'CONNECT:80'
+            else:
+                relevant = {
+                    'HTTP',
+                    'CONNECT:80',
+                    'SOCKS4',
+                    'SOCKS5',
+                } & proxy.types.keys()
+                proto = relevant.pop()
+        else:  # HTTPS
+            relevant = {'HTTPS', 'SOCKS4', 'SOCKS5'} & proxy.types.keys()
+            proto = relevant.pop()
+
+        return proto
+
+
+class HTTP(asyncio.Protocol):
+    def __init__(
+        self,
+        loop,
+        timeout,
+        max_tries,
+        prefer_connect,
+        http_allowed_codes,
+        proxy_pool,
+        resolver,
+        connect_statement=None,
+    ):
+
+        # Setting the class variables.
+        self._loop = loop
+        self._timeout = timeout
+        self._max_tries = max_tries
+        self._prefer_connect = prefer_connect
+        self._http_allowed_codes = http_allowed_codes
+        self._proxy_pool = proxy_pool
+        self._resolver = resolver
+        self._connect_statement = connect_statement
+
+        # Initiates the HttpParser object.
+        self.http_parser = HttpParser()
+
+    def connection_made(self, transport):
+        """ Begins connection with the transporter. """
+        self.transport = transport
+
+        # Getting the client address and port number.
+        self.client, self.client_ip = self.transport.get_extra_info("peername")
+
+    def data_received(self, data):
+        """ Receives unencrypted client data, and begin the emulated client process. """
+
+        self._loop.create_task(self.reply(data))
+
+    def data_received_connect(self, data):
+        self._connect_statement = data
+
+    async def reply(self, data):
+        """ Receives reply from destination server through the Emulated Client. """
+
+        # Starting our emulated client. This object talks with the server.
+        self.emulated_client = EmulatedClient(
+            loop=self._loop,
+            timeout=self._timeout,
+            max_tries=self._max_tries,
+            prefer_connect=self._prefer_connect,
+            http_allowed_codes=self._http_allowed_codes,
+            proxy_pool=self._proxy_pool,
+            resolver=self._resolver,
+            connect_statement=self._connect_statement,
+        )
+
+        # Gathering the reply from the emulated client.
+        reply = (await asyncio.gather(self.emulated_client.connect(data)))[0]
+
+        # Replies to the client that the HTTP portion of the server has connected.
+        self.transport.write(b"HTTP/1.1 200 OK\r\n\r\n")
+
+        # Writing back to the client.
+        self.transport.write(reply)
+
+        # Closing connection with the client.
+        self.transport.close()
+        self.info(
+            f"Closing connection with client {self.client}:{self.client_ip}."
+        )
+
+
+class Interceptor(asyncio.Protocol):
+    """ Class for intercepting client communication.
+
+        Notes:
+            To accomplish a proper man-in-the-middle attack with TLS capability,
+            the man-in-the-middle must be the one sending the original request to
+            the server. With the emulated client we are changing the typical structure:
+
+                client <-> server
+
+            To one that looks like so:
+
+                client <-> mitm (server) <-> mitm (emulated client) <-> server
+
+            Where we then reply back to the client with the response the emulated client
+            retrieved from the server on behalf of the client.
+    """
+
+    def __init__(
+        self,
+        loop,
+        timeout,
+        max_tries,
+        prefer_connect,
+        http_allowed_codes,
+        proxy_pool,
+        resolver,
+    ):
+
+        # Setting the class variables.
+        self._loop = loop
+        self._timeout = timeout
+        self._max_tries = max_tries
+        self._prefer_connect = prefer_connect
+        self._http_allowed_codes = http_allowed_codes
+        self._proxy_pool = proxy_pool
+        self._resolver = resolver
+        self._connect_statement = None
+
+        # Initiates the HttpParser object.
+        self.http_parser = HttpParser()
+
+        # Initiating our HTTP transport with the emulated client.
+        self.HTTP_Protocol = HTTP(
+            loop=self._loop,
+            timeout=self._timeout,
+            max_tries=self._max_tries,
+            prefer_connect=self._prefer_connect,
+            http_allowed_codes=self._http_allowed_codes,
+            proxy_pool=self._proxy_pool,
+            resolver=self._resolver,
+            connect_statement=self._connect_statement,
+        )
+
+        # We only initialize our HTTPS_Protocol when we get a CONNECT statement.
+        self.HTTPS_Protocol = None
+
+        # Creates the TLS flag.
+        self.using_tls = False
+
+    def connection_made(self, transport):
+        """ Called when client makes initial connection to the server. Receives a transporting object from the client. """
+        # Setting our transport object.
+        self.transport = transport
+
+        # Getting the client address and port number.
+        self.client, self.client_ip = self.transport.get_extra_info("peername")
+
+    def data_received(self, data):
+        """
+            Called when a connected client sends data to the server; HTTP or HTTPS requests.
+
+            Note:
+                This method is called multiple times during a typical TLS/SSL connection with a client.
+                    1. Client sends server message to connect; "CONNECT."
+                    2. Server replies with "OK" and begins handshake.
+                    3. Client sends server encrypted HTTP requests; "GET", "POST", etc.
+        """
+
+        # Parses the data the client has sent to the server.
+        self.http_parser.execute(data, len(data))
+
+        if (
+            self.http_parser.get_method() == "CONNECT"
+            and self.using_tls == False
+        ):
+
+            # Logging we are using HTTPS.
+            log.info(
+                f"Connected with client {self.client}:{self.client_ip} with HTTPS."
+            )
+
+            # Generating the SSL certificate and keys if needed.
+            if not os.path.exists("ssl"):
+                create_self_signed_cert()
+                log.info(
+                    "Generating SSL certificate to communicate with client."
+                )
+
+            # Saves the CONNECT response for later use.
+            self._connect_statement = data
+
+            # Loading the protocol certificates.
+            ssl_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+            ssl_context.load_cert_chain("ssl/server.crt", "ssl/server.key")
+
+            # Initialize the HTTPS_Protocol.
+            self.HTTPS_Protocol = asyncio.sslproto.SSLProtocol(
+                loop=self._loop,
+                app_protocol=self.HTTP_Protocol,
+                sslcontext=ssl_context,
+                waiter=None,
+                server_side=True,
+            )
+
+            # Replies to the client that the server has connected.
+            self.transport.write(b"HTTP/1.1 200 OK\r\n\r\n")
+            # Sending initial CONNECT request over for handshake.
+            self.HTTPS_Protocol.data_received(data)
+            # Sending initial CONNECT request over to store it.
+            self.HTTPS_Protocol._app_protocol.data_received_connect(data)
+            # Does a TLS/SSL handshake with the client.
+            self.HTTPS_Protocol.connection_made(self.transport)
+            # Sets TLS flag as on -- after exiting this if statement, the data will be encrypted.
+            self.using_tls = True
+        elif self.using_tls:
+            # With HTTPS protocol enabled, receives encrypted data from the client (gets decrypted by data_received).
+            self.HTTPS_Protocol.data_received(data)
+        else:
+            # Logging we are using HTTP.
+            log.info(
+                f"Connected with client {self.client}:{self.client_ip} with HTTP."
+            )
+
+            # Receives standard, non-encrypted data from the client (TLS/SSL is off).
+            self.HTTP_Protocol.connection_made(self.transport)
+            self.HTTP_Protocol.data_received(data)

--- a/proxybroker/server.py
+++ b/proxybroker/server.py
@@ -114,9 +114,11 @@ class Server:
         )
         self._server = self._loop.run_until_complete(srv)
 
+        url, ip = self._server.sockets[0].getsockname()
+
         log.info(
-            'Listening established on {0}'.format(
-                self._server.sockets[0].getsockname()
+            'ProxyBroker established on {}:{}'.format(
+                url, ip
             )
         )
 

--- a/proxybroker/server.py
+++ b/proxybroker/server.py
@@ -105,6 +105,7 @@ class Server(asyncio.Protocol):
             ),
             host=self.host,
             port=self.port,
+            backlog=self._backlog,
         )
 
         # Prints information about the server.

--- a/proxybroker/utils.py
+++ b/proxybroker/utils.py
@@ -15,7 +15,13 @@ from .errors import BadStatusLine
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 DATA_DIR = os.path.join(BASE_DIR, 'data')
-log = logging.getLogger(__package__)
+logging.basicConfig(
+    format='%(message)s',
+    datefmt='[%H:%M:%S]',
+    level='INFO',
+    handlers=[logging.StreamHandler()],
+)
+log = logging
 
 IPPattern = re.compile(
     r'(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,3 +2,5 @@ aiohttp>=3.5.4
 aiodns>=2.0.0
 attrs==19.1.0
 maxminddb>=1.4.1
+PyOpenSSL
+git+https://github.com/benoitc/http-parser


### PR DESCRIPTION
This is a very bootleg addition to the project to add a man-in-the-middle attack to allow ProxyBroker to check HTTPS requests and the returned headers. One of the biggest missing things on ProxyBroker was the ability to verify the return response from the servers if using HTTPS. This pull request allows that.

By creating a man-in-the-middle server ProxyBroker essentially goes from:

```
client <-> ProxyBroker <-> public proxy <-> server
```

To

```
client <-> ProxyBroker (server)
ProxyBroker (emulated client) <-> public proxy <-> server
```

By emulating the client we are able to take a peek at the responding HTTPS request coming back from the server, allowing us to ensure that the return was that actually warranted by the `http_allowed_codes`. This is an extremely *temporary fix* to the larger problem. The reality is that the entire project needs to be refactored with better usage of codes, exception throws, etc. It should also be mentioned that this PR does not include essentials like `POST`, `SET`, etc -- only `GET`. 

If you do choose to use this implementation, you must also ensure that you either add the generated SSL certificate to your keychain or that you properly tell `aiohttp` or `requests` within your own applications to not bother checking SSL certificates. You can see a small implementation of a Python man-in-the-middle [here](https://github.com/synchronizing/mitm/) for a better sense of the implementations here. 

---

* Tests need to be expanded on for this PR.
* Add support for other HTTP methods; `POST`, `SET`, `DELETE`, etc. 